### PR TITLE
CASMPET-7084 add node-role.kubernetes.io/control-plane toleration for k8s 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		cray-node-problem-detector
 
 package:

--- a/charts/cray-node-problem-detector/Chart.yaml
+++ b/charts/cray-node-problem-detector/Chart.yaml
@@ -24,7 +24,7 @@
 #
 apiVersion: v2
 name: cray-node-problem-detector
-version: 1.9.0
+version: 1.10.0
 description: Cray node problem detecor for monitoring extra attributes on nodes
 keywords:
   - node-problem-detector

--- a/charts/cray-node-problem-detector/Chart.yaml
+++ b/charts/cray-node-problem-detector/Chart.yaml
@@ -1,4 +1,3 @@
-
 #
 # MIT License
 #

--- a/charts/cray-node-problem-detector/values.yaml
+++ b/charts/cray-node-problem-detector/values.yaml
@@ -58,3 +58,6 @@ node-problem-detector:
   - key: "node-role.kubernetes.io/master"
     operator: "Exists"
     effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"


### PR DESCRIPTION
## Summary and Scope

Add "node-role.kubernetes.io/control-plane" toleration for k8s 1.24. This is necessary for the k8s 1.24 upgrade happening in CSM 1.6.

## Issues and Related PRs

* Resolves [CASMPET-7084](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7084)

## Testing

Upgraded this chart on Beau successfully.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

