### PR TITLE
CASMPET-7331: Disable PSP

### DIFF
--- a/charts/cray-node-problem-detector/Chart.yaml
+++ b/charts/cray-node-problem-detector/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-node-problem-detector
-version: 1.11.0
+version: 1.11.1
 description: Cray node problem detecor for monitoring extra attributes on nodes
 keywords:
   - node-problem-detector

--- a/charts/cray-node-problem-detector/values.yaml
+++ b/charts/cray-node-problem-detector/values.yaml
@@ -39,7 +39,7 @@ node-problem-detector:
 
   rbac:
     create: true
-    pspEnabled: true
+    pspEnabled: false
 
   settings:
     log_monitors:


### PR DESCRIPTION
## Summary and Scope
Disable PSP so it can run on a K8s 1.32 system.

## Issues and Related PRs

* Resolves [CASMPET-7331](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7331)

## Testing
Install chart on `beau` running k8s 1.24 and `molly` running k8s 1.32.

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

